### PR TITLE
Quieter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,4 @@ config.json.live
 config.json.old
 .save.json.swp
 config.json
+log

--- a/button.service
+++ b/button.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=A discord bot that interacts with GPIO pins to receive instructions
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /home/pi/github/DiscordHueButton/initscript
+RestartSec=15
+Restart=always
+KillMode=mixed
+
+[Install] 
+WantedBy=multi-user.target

--- a/configHelper.py
+++ b/configHelper.py
@@ -8,9 +8,9 @@ class configHelper():
     def __init__(self) -> None:
         self.logger = logging.getLogger("configHelper")
         
-
-        self.messages = {}
-        self.channels = {}
+        self.openMessages = []
+        self.messages = []
+        self.channels = [] #the ID is the key, the object is the 
         keys = {} 
 
         try: 

--- a/configHelper.py
+++ b/configHelper.py
@@ -9,7 +9,6 @@ class configHelper():
         self.logger = logging.getLogger("configHelper")
         
         self.openMessages = []
-        self.messages = []
         self.channels = [] #the ID is the key, the object is the 
         keys = {} 
 
@@ -25,16 +24,8 @@ class configHelper():
         except Exception as e:
             self.logger.error("Couldn't properly parse 'last pressed' %s",e)
 
-        self.messages = {} if "lastMessages" not in keys else keys["lastMessages"]
-        for key in self.messages:
-            
-            try:
-                value = self.messages[key]
-                self.messages.pop(key)
-                newKey = int(key)
-                self.messages[newKey] = value
-            except Exception as e:
-                logging.warning("Couldn't properly convert a lastMessage key from string to int - [%s]", key)
+        self.openMessages = [] if "openMessages" not in keys else keys["openMessages"]
+
                 
                 
                 
@@ -67,7 +58,13 @@ class configHelper():
         selection = random.randint(0,len(self.despairMessages)-1)
         return self.despairMessages[selection]
 
+    def registerOpenMessage(self,messageID,channelID):
+        self.openMessages.append({"message":messageID,"channel":channelID})
+        self.saveProgress()
 
+    def unregisterOpenMessage(self,messageID,channelID):
+        self.openMessages.remove({"message":messageID,"channel":channelID})
+        self.saveProgress()
     def registerChannel(self, channelID):
         if channelID not in self.channels:
             self.channels.append(channelID)
@@ -101,7 +98,7 @@ class configHelper():
         f =  open("save.json.new","w") 
         outObj["timesPressed"] = self.presses
         outObj["lastPressed"] = datetime.datetime.strftime(self.lastPressed, r"%Y-%m-%d %H:%M:%S")
-        outObj["lastMessages"] = self.messages
+        outObj["openMessages"] = self.openMessages
         try:
             outStr = json.dumps(outObj, indent=2)
             f.write(outStr)
@@ -130,7 +127,6 @@ class configHelper():
             outObj = {}
             outObj["usersToWatchFor"] = self.users
 
-            outObj["announcementChannels"] = self.channels
             
             
             outObj["despairMessages"] = self.despairMessages

--- a/statusLED.py
+++ b/statusLED.py
@@ -34,6 +34,9 @@ class statusLight:
         self._pulsespeed = speed
 
 
+    def terminate(self):
+        self._continueLoop = False
+
     def _loop(self):
         while self._continueLoop:
             if datetime.now() < self._flashEndTime and self._stateFlag == "flashing":


### PR DESCRIPTION
Removed announcements in favour of direct invocations (it was annoying people) 
Added help breadcrumb via activity
Changed register and unregister commands to return "we don't do that anymore" notices
Changed mention response to be a reaction, not a reply
On button-press, any outstanding mentions have their reactions changed (bit glitchy, doesn't always get them all)

Added example service for systemctl 

Fixed an issue causing the LED thread to keep the bot running forever in the event of a crash / failed execution.